### PR TITLE
Add implementation plan and basic CLI structure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,242 @@
 version = 4
 
 [[package]]
+name = "anstream"
+version = "0.6.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "syn"
+version = "2.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
 name = "uproda"
 version = "0.1.0"
+dependencies = [
+ "clap",
+]
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+clap = { version = "4.5.4", features = ["derive"] }

--- a/docs/implementation_plan.md
+++ b/docs/implementation_plan.md
@@ -1,0 +1,71 @@
+# Implementation Plan
+
+This document outlines the development plan for the Uproda CLI tool. The implementation is divided into several focused feature branches to ensure manageable, reviewable, and testable changes.
+
+## 1. Branch: `feature/cli-structure`
+
+**Goal:** Implement the basic command-line interface structure.
+
+*   **Tasks:**
+    *   Use the `clap` crate to define command-line arguments.
+    *   The CLI should accept one or more file paths for upload.
+    *   Add an optional argument for the target server URL (e.g., `--url <URL>`).
+    *   Implement a basic handler that parses the arguments and prints the collected file paths and the target URL to the console.
+    *   Ensure basic TDD principles are followed by writing a test that verifies argument parsing.
+
+## 2. Branch: `feature/single-file-upload`
+
+**Goal:** Implement the logic for uploading a single file.
+
+*   **Prerequisites:** `feature/cli-structure`
+*   **Tasks:**
+    *   Create a new `uploader` module to encapsulate the upload logic.
+    *   Within the `uploader` module, implement a function that takes a file path and a target URL.
+    *   Use the `reqwest` and `tokio` crates to send the file's content as an asynchronous POST request.
+    *   For initial testing, use a public endpoint like `httpbin.org/post`.
+    *   Add a unit test for the upload function, potentially using a mock server or `httpbin.org`.
+
+## 3. Branch: `feature/parallel-uploads`
+
+**Goal:** Enable the concurrent upload of multiple files.
+
+*   **Prerequisites:** `feature/single-file-upload`
+*   **Tasks:**
+    *   Modify the `main` function to handle multiple file path arguments.
+    *   For each file path, spawn an asynchronous task using `tokio::spawn` that calls the single-file upload function.
+    *   Use `futures::future::join_all` or a similar mechanism to wait for all upload tasks to complete.
+    *   Report the success or failure of each upload.
+
+## 4. Branch: `feature/progress-indicator`
+
+**Goal:** Integrate progress bars to provide user feedback during uploads.
+
+*   **Prerequisites:** `feature/parallel-uploads`
+*   **Tasks:**
+    *   Add the `indicatif` crate to the project dependencies.
+    *   Implement a multi-progress bar setup.
+    *   Create a main progress bar to track the overall progress (number of files uploaded / total files).
+    *   For each individual file upload, create a separate progress bar to show the transfer progress (bytes sent / total bytes).
+    *   Use `reqwest`'s streaming capabilities to feed the real-time upload progress to the `indicatif` progress bars.
+
+## 5. Branch: `feature/error-handling-and-config`
+
+**Goal:** Improve robustness through comprehensive error handling and flexible configuration.
+
+*   **Prerequisites:** `feature/progress-indicator`
+*   **Tasks:**
+    *   Define custom error types using a crate like `thiserror` to handle various failure scenarios (e.g., file not found, network error, server error).
+    *   Refactor the existing code to use `Result<T, E>` for all operations that can fail.
+    *   Provide clear, user-friendly error messages.
+    *   (Optional) Extend configuration options to allow reading the server URL from a configuration file (e.g., `config.toml`) or environment variables, in addition to CLI arguments.
+
+## 6. Branch: `refactor/docs-and-cleanup`
+
+**Goal:** Refactor the codebase, add documentation, and ensure code quality.
+
+*   **Prerequisites:** `feature/error-handling-and-config`
+*   **Tasks:**
+    *   Review the entire codebase for clarity, maintainability, and performance.
+    *   Add `rustdoc` comments to all public functions, structs, and modules.
+    *   Run `cargo fmt` to ensure consistent formatting.
+    *   Run `cargo clippy -- -D warnings -A clippy::pedantic` and fix all reported lints to adhere to the zero-warnings policy.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,32 @@
+use clap::Parser;
+
+/// A simple CLI to upload multiple files concurrently.
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// The path to the file(s) to upload.
+    #[arg(required = true)]
+    files: Vec<String>,
+
+    /// The target server URL.
+    #[arg(short, long)]
+    url: String,
+}
+
 fn main() {
-    println!("Hello, world!");
+    let args = Args::parse();
+
+    println!("Files to upload: {:?}", args.files);
+    println!("Target URL: {}", args.url);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn verify_cli() {
+        use clap::CommandFactory;
+        Args::command().debug_assert();
+    }
 }


### PR DESCRIPTION
Introduce an implementation plan for the Uproda CLI tool, outlining the development process across multiple feature branches. Implement the basic command-line interface using `clap`, allowing for file path and server URL input, along with a test to verify the configuration.