### PR TITLE
Add parallel file upload functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,12 +274,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -287,6 +303,17 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -323,6 +350,7 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -962,7 +990,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1554,6 +1582,7 @@ name = "uproda"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "futures",
  "reqwest",
  "tempfile",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,5 @@ reqwest = { version = "0.12.4", features = ["json", "multipart", "stream", "rust
 tokio = { version = "1.37.0", features = ["full"] }
 tokio-util = { version = "0.7.11", features = ["codec"] }
 tempfile = "3.10.1"
+futures = "0.3.30"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 use clap::Parser;
 use std::path::Path;
+use futures::future::join_all;
+use std::error::Error;
 
 mod uploader;
 
@@ -17,16 +19,34 @@ struct Args {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let args = Args::parse();
 
-    // For now, we only upload the first file.
-    // In a later step, we will handle multiple files concurrently.
-    if let Some(file_path_str) = args.files.first() {
-        let file_path = Path::new(file_path_str);
-        uploader::upload_file(file_path, &args.url).await?;
-    } else {
+    if args.files.is_empty() {
         eprintln!("No files provided for upload.");
+        return Ok(());
+    }
+
+    let mut tasks = vec![];
+    for file_path_str in args.files {
+        let file_path = Path::new(&file_path_str).to_owned();
+        let url = args.url.clone();
+        tasks.push(tokio::spawn(async move {
+            let file_name = file_path.file_name().and_then(|n| n.to_str()).unwrap_or("unknown");
+            match uploader::upload_file(&file_path, &url).await {
+                Ok(_) => println!("Finished uploading {}", file_name),
+                Err(e) => eprintln!("Failed to upload {}: {}", file_name, e),
+            }
+            Ok::<(), Box<dyn Error + Send + Sync>>(()) // Return a Result from the spawned task
+        }));
+    }
+
+    let results = join_all(tasks).await;
+
+    for result in results {
+        if let Err(e) = result {
+            eprintln!("Task failed: {}", e);
+        }
     }
 
     Ok(())
@@ -35,10 +55,45 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::NamedTempFile;
+    use std::io::Write;
 
     #[test]
     fn verify_cli() {
         use clap::CommandFactory;
         Args::command().debug_assert();
+    }
+
+    #[tokio::test]
+    async fn test_parallel_uploads() -> Result<(), Box<dyn Error + Send + Sync>> {
+        let num_files = 3;
+        let mut temp_files = Vec::new();
+        let mut file_paths = Vec::new();
+
+        for i in 0..num_files {
+            let mut temp_file = NamedTempFile::new()?;
+            temp_file.write_all(format!("This is test file {}.", i).as_bytes())?;
+            file_paths.push(temp_file.path().to_owned());
+            temp_files.push(temp_file); // Keep temp_file in scope
+        }
+
+        let url = "https://httpbin.org/post";
+
+        let mut tasks = vec![];
+        for file_path in file_paths {
+            let url_clone = url.to_string();
+            tasks.push(tokio::spawn(async move {
+                uploader::upload_file(&file_path, &url_clone).await
+            }));
+        }
+
+        let results = join_all(tasks).await;
+
+        for result in results {
+            assert!(result.is_ok()); // Check if the task itself completed without panicking
+            assert!(result.unwrap().is_ok()); // Check if the upload was successful
+        }
+
+        Ok(())
     }
 }

--- a/src/uploader.rs
+++ b/src/uploader.rs
@@ -3,7 +3,7 @@ use tokio::fs::File;
 use tokio_util::codec::{BytesCodec, FramedRead};
 use std::path::Path;
 
-pub async fn upload_file(file_path: &Path, url: &str) -> Result<(), Box<dyn std::error::Error>> {
+pub async fn upload_file(file_path: &Path, url: &str) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let client = Client::new();
     let file_name = file_path.file_name().ok_or("Invalid file name")?.to_str().ok_or("Invalid file name")?;
 
@@ -38,7 +38,7 @@ pub async fn upload_file(file_path: &Path, url: &str) -> Result<(), Box<dyn std:
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tokio::io::AsyncWriteExt;
+    
     use tempfile::NamedTempFile;
     use std::io::Write;
 


### PR DESCRIPTION
Introduce the `futures` crate to enable concurrent file uploads. Modify the main upload logic to utilize asynchronous tasks for handling multiple files simultaneously. Update error handling for thread safety and add a test case to verify the new parallel upload feature.